### PR TITLE
Test error provider

### DIFF
--- a/packages/name-service/src/App/routes/Contract/index.tsx
+++ b/packages/name-service/src/App/routes/Contract/index.tsx
@@ -1,5 +1,5 @@
 import { Typography } from "antd";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import Center from "../../../theme/layout/Center";
 import Stack from "../../../theme/layout/Stack";
@@ -9,6 +9,7 @@ import YourAccount from "../../components/YourAccount";
 import FormSearchName from "./components/FormSearchName";
 import SearchResult from "./components/SearchResult";
 import "./Contract.less";
+import { useError } from "../../../service";
 
 const { Title, Text } = Typography;
 
@@ -19,9 +20,15 @@ interface ContractParams {
 
 function Contract(): JSX.Element {
   const { label, address } = useParams() as ContractParams;
+  const { error, setError, clearError } = useError();
 
   const [loading, setLoading] = useState(false);
   const [searchedName, setSearchedName] = useState("");
+
+  useEffect(() => {
+    console.log(error);
+    setError("Effect error");
+  }, [error, setError]);
 
   return (
     (loading && <Loading loadingText={`Registering name: ${searchedName}...`} />) ||
@@ -31,7 +38,20 @@ function Contract(): JSX.Element {
           <BackButton />
           <Stack className="SearchAndResultStack">
             <Stack className="SearchStack">
-              <Title>{label}</Title>
+              <div
+                onClick={() => {
+                  clearError();
+                }}
+              >
+                <Title>{label}</Title>
+              </div>
+              <div
+                onClick={() => {
+                  setError("asd");
+                }}
+              >
+                <Title>{error}</Title>
+              </div>
               <Text>({address})</Text>
               <FormSearchName setSearchedName={setSearchedName} />
             </Stack>

--- a/packages/name-service/src/App/routes/Home/index.tsx
+++ b/packages/name-service/src/App/routes/Home/index.tsx
@@ -14,7 +14,7 @@ import "./Home.less";
 const { Title } = Typography;
 
 function Home(): JSX.Element {
-  const { setError } = useError();
+  const { setError, error } = useError();
   const sdk = useSdk();
 
   const [contracts, setContracts] = useState<readonly Contract[]>([]);
@@ -33,12 +33,22 @@ function Home(): JSX.Element {
     }
   }, [sdk, setError]);
 
+  useEffect(() => {
+    setTimeout(() => {
+      Promise.reject("Test reject").catch((error) => {
+        setError(error);
+        console.error(error);
+      });
+    }, 5000);
+  }, [setError]);
+
   return !sdk.initialized ? (
     <Loading loadingText="Initializing app..." />
   ) : (
     <Center tag="main" className="Home">
       <Stack>
         <Title>Name Service</Title>
+        {error && <Title>{error}</Title>}
         <Stack tag="nav">
           {contracts.map(({ label, address }) => (
             <Link key={address} to={`${pathContract}/${label.toLowerCase()}/${address}`}>

--- a/packages/name-service/src/service/error.tsx
+++ b/packages/name-service/src/service/error.tsx
@@ -1,73 +1,34 @@
 import * as React from "react";
 
-/*
-Ugly to use a singleton to manage functions, but the issue is that we want to return the same
-setError, clearError functions to the consumers, so they don't trigger new effects everytime
-we update the error state, which can lead to an infinite loop:
-
-Component.useEffect returns error, calls setError
-ErrorProvider updates value and returns new closure for setError
-useEffect is triggered again, with another error....
-
-When this is updated, we only want things to re-render that depend on the actual error value.
-There may be cleaner ways to do this but encapsulating a singleton here seemed fine.
-(We can't rely on local variables that change each time ErrorProvider() is called).
-*/
-
-let initError: string | undefined;
-
-// this should be set on first render
-let callback = (state: State): void => {
-  // this is overriden on first render
-  initError = state.error;
-};
-
-function setError(err: any): void {
-  const error = typeof err === "string" ? err : err.toString();
-  callback({ error });
-}
-
-function clearError(): void {
-  callback({});
-}
-
-/** ****************/
-
 interface ErrorContextType {
   readonly error?: string;
-  readonly setError: (err: string) => void;
+  readonly setError: (error: string) => void;
   readonly clearError: () => void;
 }
 
-const defaultContext = (): ErrorContextType => {
-  return {
-    setError,
-    clearError,
-  };
+const defaultContext: ErrorContextType = {
+  setError: () => {
+    return;
+  },
+  clearError: () => {
+    return;
+  },
 };
 
-const ErrorContext = React.createContext<ErrorContextType>(defaultContext());
+const ErrorContext = React.createContext<ErrorContextType>(defaultContext);
 
 export const useError = (): ErrorContextType => React.useContext(ErrorContext);
 
-interface State {
-  readonly error?: string;
-}
-
-export function ErrorProvider(props: { readonly children: any }): JSX.Element {
-  const [value, setValue] = React.useState<State>({});
-  callback = setValue;
-  // if there is an error before we render the first time, make sure we render it
-  if (initError) {
-    setValue({ error: initError });
-    initError = undefined;
-  }
+export function ErrorProvider({ children }: React.HTMLAttributes<HTMLOrSVGElement>): JSX.Element {
+  const [error, setError] = React.useState<string>();
 
   const context: ErrorContextType = {
-    error: value.error,
-    setError,
-    clearError,
+    error: error,
+    setError: setError,
+    clearError: () => {
+      setError(undefined);
+    },
   };
 
-  return <ErrorContext.Provider value={context}>{props.children}</ErrorContext.Provider>;
+  return <ErrorContext.Provider value={context}>{children}</ErrorContext.Provider>;
 }


### PR DESCRIPTION
I have not been able to reproduce the documented infinite loop in Error Provider:

In this PR I have set some ways to update the error by clicking some titles, by useEffect, and by useEffect + setTimeout, and was not able to see any difference between the old implementation of Error Provider and the new.