### PR TITLE
Sdk reset client

### DIFF
--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
       "@cosmicdapp/design": "^0.4.4",
-      "@cosmicdapp/logic": "^0.4.4",
+      "@cosmicdapp/logic": "^0.4.5",
       "antd": "^4.5.4",
       "formik": "^2.1.5",
       "formik-antd": "^2.0.1",

--- a/packages/cw20-wallet/package.json
+++ b/packages/cw20-wallet/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.2.2",
     "@cosmicdapp/design": "^0.4.4",
-    "@cosmicdapp/logic": "^0.4.4",
+    "@cosmicdapp/logic": "^0.4.5",
     "@cosmjs/cosmwasm": "^0.23.1",
     "@cosmjs/crypto": "^0.23.1",
     "@cosmjs/launchpad": "^0.23.1",

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.2.2",
-    "@cosmicdapp/logic": "^0.4.4",
+    "@cosmicdapp/logic": "^0.4.5",
     "clipboard-copy": "^3.1.0"
   },
   "peerDependencies": {

--- a/packages/logic/package.json
+++ b/packages/logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmicdapp/logic",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "license": "Apache-2.0",
   "description": "Utilities for CosmJS-based dApps",
   "contributors": [

--- a/packages/logic/src/service/wallet.tsx
+++ b/packages/logic/src/service/wallet.tsx
@@ -27,7 +27,7 @@ const defaultContext: CosmWasmContextType = {
   initialized: false,
   address: "",
   config: {},
-  init: () => {},
+  init: throwNotInitialized,
   clear: throwNotInitialized,
   getSigner: throwNotInitialized,
   getClient: throwNotInitialized,

--- a/packages/name-service/package.json
+++ b/packages/name-service/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@cosmicdapp/design": "^0.4.4",
-    "@cosmicdapp/logic": "^0.4.4",
+    "@cosmicdapp/logic": "^0.4.5",
     "@cosmjs/cosmwasm": "^0.23.1",
     "@cosmjs/launchpad": "^0.23.1",
     "antd": "^4.5.4",

--- a/packages/staking-service/package.json
+++ b/packages/staking-service/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@cosmicdapp/design": "^0.4.4",
-    "@cosmicdapp/logic": "^0.4.4",
+    "@cosmicdapp/logic": "^0.4.5",
     "@cosmjs/launchpad": "^0.23.1",
     "@cosmjs/math": "^0.23.1",
     "antd": "^4.5.4",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@cosmicdapp/design": "^0.4.4",
-    "@cosmicdapp/logic": "^0.4.4",
+    "@cosmicdapp/logic": "^0.4.5",
     "@cosmjs/launchpad": "^0.23.1",
     "antd": "^4.5.4",
     "formik": "^2.1.5",


### PR DESCRIPTION
Add `changeConfig` and `changeSigner` methods to the Sdk provider, which are needed by code-explorer